### PR TITLE
TCP 13 WordPress post type and ID as asset identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Then...
 
 ## HTTPS and Dev Mode
 
-Your site must be served over `https` in order to integrate with Talk **unless** Talk is set to dev mode. If you're installing Talk with Docker, you can do that by adding `NODE_ENV=dev` to the environment variables in your `docker-compose.yml` ([more info](https://github.com/coralproject/talk/blob/master/INSTALL.md#installing)).
+Your site must be served over `https` in order to integrate with Talk **unless** Talk is set to dev mode.
+
+If you're installing Talk with Docker, you can do that by adding `NODE_ENV=dev` to the environment variables in your [`docker-compose.yml`](https://github.com/coralproject/talk/blob/master/INSTALL.md#installing). Otherwise, any method of setting `process.env.NODE_ENV = 'dev'` will do the trick.
 
 ## Theme usage
 

--- a/inc/class-talk-default-comments-settings.php
+++ b/inc/class-talk-default-comments-settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Adjust WordPress comments settings display in WP Admin with Coral Talk is active
+ * Adjust WordPress comments settings display in WP Admin while Coral Talk is active
  *
  * @package Talk_Plugin
  */

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -13,7 +13,8 @@ if ( ! empty( $talk_url ) ) : ?>
 	<div id="coral_talk_<?php echo absint( $rand ); ?>"></div>
 	<script src="<?php echo esc_url( $talk_url . '/embed.js' ); ?>" async onload="
 		Coral.Talk.render(document.getElementById('coral_talk_<?php echo absint( $rand ); ?>'), {
-			talk: '<?php echo esc_url( $talk_url ); ?>'
+			talk: '<?php echo esc_url( $talk_url ); ?>',
+			asset_id: '<?php echo esc_js( coral_talk_get_asset_id() ); ?>'
 		});
 	"></script>
 <?php endif;

--- a/talk.php
+++ b/talk.php
@@ -63,4 +63,15 @@ function coral_talk_comments_template() {
 	require( coral_talk_get_comments_template_path() );
 }
 
+/**
+ * Construct asset_id based on current post type and ID.
+ * Must be used inside The Loop.
+ *
+ * @return string asset_id
+ * @since 0.0.2
+ */
+function coral_talk_get_asset_id() {
+	return get_post_type() . '-' . get_the_ID();
+}
+
 new Talk_Plugin;


### PR DESCRIPTION
Use this to override Coral's default, which is the URL (which is subject to change)