### PR TITLE
Don't render comments on pages with comments disabled

### DIFF
--- a/talk.php
+++ b/talk.php
@@ -25,7 +25,7 @@ class Talk_Plugin {
 		require_once( CORAL_PROJECT_TALK_DIR . '/inc/class-talk-settings-page.php' );
 		require_once( CORAL_PROJECT_TALK_DIR . '/inc/class-talk-default-comments-settings.php' );
 		add_filter( 'comments_template', function( $default_template_path ) {
-			return coral_talk_plugin_is_usable() ?
+			return coral_talk_plugin_is_usable() && coral_talk_plugin_enable_for_page() ?
 				coral_talk_get_comments_template_path() :
 				$default_template_path;
 		}, 99 );
@@ -50,6 +50,30 @@ class Talk_Plugin {
 function coral_talk_plugin_is_usable() {
 	$talk_url = get_option( 'coral_talk_base_url' );
 	return ! empty( $talk_url );
+}
+
+/**
+ * Check if comments should be rendered for the current page
+ *
+ * @since 0.1.1
+ * @return bool
+ */
+function coral_talk_plugin_enable_for_page() {
+	global $post;
+	if ( ! isset( $post ) ) {
+		return false;
+	}
+	// Don't render if comments are off for this post
+	if ( ! comments_open() ) {
+		return false;
+	}
+	// Don't render if this is a preview
+	if ( in_array( $post->post_status, array(
+		'draft', 'auto-draft', 'pending', 'future', 'trash'
+	) ) ) {
+		return false;
+	}
+	return true;
 }
 
 /**


### PR DESCRIPTION
The README suggests using the following in a custom theme:

```
if ( comments_open() ) {
	coral_talk_comments_template();
}
```

Without a custom theme, the code instead uses the WordPress `comments_template` filter. However, there's no check in this logic for `comments_open()`, so comments get rendered on pages with comments disabled.

Additionally, when a draft post is previewed, Talk comments are rendered. This leads to a few issues with autopopulating the assets record, primarily that WordPress doesn't typically generate the pretty URL as the canonical URL - that is, the "canonical" URL will be `yourdomain.com/?p=1234` rather than `yourdomain.com/post-name/`. This leads to multiple asset records, one for the draft version of the post and one for the published version.

The solution is a simple check for both of these states in the filter code.

Testing: comments are still rendered for published posts with comments enabled; comments are not rendered for posts with comments disabled, or for previews of draft posts.