### PR TITLE
[CORL-462] Update the wordpress plugin to support Coral version 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-# Coral Project Talk
+# Coral Plugin
 
-This plugin replaces standard WordPress commenting with [Talk](https://coralproject.net/products/talk.html) from the [Coral Project](https://coralproject.net).
+This plugin replaces standard WordPress commenting with [Coral](https://coralproject.net/products/talk.html) from the [Coral Project](https://coralproject.net).
 
 ## Setup
 
-First, you'll need a server running your own instance of Talk. See the [Talk Docs](https://docs.coralproject.net/talk/) for more info about that.
+First, you'll need a server running your own instance of Coral. See the [Coral Docs](https://docs.coralproject.net/talk/) for more info about that.
 
 Then...
 
-1. Add the hostname of your WordPress site to the whitelist in the settings of your Talk instance.
+1. Add the hostname of your WordPress site to the whitelist in the settings of your Coral instance.
 1. Install and activate this plugin as you would any other WordPress plugin.
 1. Go to `https://mysite.com/wp-admin/options-general.php?page=talk-settings`
-1. Enter the URL of your Talk instance and click Save.
+1. Enter the URL of your Coral instance and click Save.
 
 ## HTTPS and Dev Mode
 
-Your site must be served over `https` in order to integrate with Talk **unless** Talk is set to dev mode.
+Your site must be served over `https` in order to integrate with Coral **unless** Coral is set to dev mode.
 
-If you're installing Talk with Docker, you can do that by adding `NODE_ENV=dev` to the environment variables in your [`docker-compose.yml`](https://docs.coralproject.net/talk/installation-from-docker/). Otherwise, any method of setting `process.env.NODE_ENV = 'dev'` will do the trick.
+If you're installing Coral with Docker, you can do that by adding `NODE_ENV=dev` to the environment variables in your [`docker-compose.yml`](https://docs.coralproject.net/talk/installation-from-docker/). Otherwise, any method of setting `process.env.NODE_ENV = 'dev'` will do the trick.
 
 ## Theme usage
 
-If your theme uses WordPress' standard `comments_template()` to render comments forms, the output will be overridden by the Talk embed code.
+If your theme uses WordPress' standard `comments_template()` to render comments forms, the output will be overridden by the Coral embed code.
 
 If you are building a custom theme, we recommend using `coral_talk_comments_template()` instead of the usual `comments_template()` for performance reasons.
 
@@ -29,7 +29,7 @@ Note that comments can still be turned on or off for an invidual post:
 
 ![Discussion meta box](lib/img/discussion-meta-box.png)
 
-[`comments_open()`](https://codex.wordpress.org/Function_Reference/comments_open) will still work when Coral Project Talk is active, but other functions like [`get_comments_number()`](https://codex.wordpress.org/Template_Tags/get_comments_number) that reference the `wp_comments` database table may not.
+[`comments_open()`](https://codex.wordpress.org/Function_Reference/comments_open) will still work when the Coral Plugin is active, but other functions like [`get_comments_number()`](https://codex.wordpress.org/Template_Tags/get_comments_number) that reference the `wp_comments` database table may not.
 
 We recommend something like:
 
@@ -40,6 +40,8 @@ if ( comments_open() ) {
 ```
 
 ## Version
-Talk version <= `v3.9.1` use talk-wp-plugin `v0.0.6`
+Coral version <= `v3.9.1` use plugin version `v0.0.6`
 
-Talk version >= `4.0.0` use talk-wp-plugin `v0.1.0`
+Coral version >= `4.0.0` use plugin version `v0.1.0`
+
+Coral version >= `5.0.0` use plugin version `v0.2.0`

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Coral Project Talk">
-	<description>PHP_CodeSniffer standard for the Coral Project Talk plugin</description>
+<ruleset name="Coral Project">
+	<description>PHP_CodeSniffer standard for the Coral Project plugin</description>
 	<rule ref="WordPress">
 		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
 		<exclude name="Squiz.Commenting.FileComment.Missing" />

--- a/inc/class-talk-default-comments-settings.php
+++ b/inc/class-talk-default-comments-settings.php
@@ -15,7 +15,7 @@ class Talk_Default_Comments_Settings {
 		} );
 		add_action( 'post_comment_status_meta_box-options', function() {
 			printf( '<p><em>%s</em></p>',
-				esc_html__( 'Comments managed by Coral Project Talk', 'coral-project-talk' )
+				esc_html__( 'Comments managed by Coral Project', 'coral-project-talk' )
 			);
 		} );
 	}
@@ -30,7 +30,7 @@ class Talk_Default_Comments_Settings {
 		if ( 'options-discussion' === $screen->base ) {
 			coral_talk_print_admin_notice(
 				'success',
-				__( 'Comments are managed by Coral Project Talk. (%ssettings%s)', 'coral-project-talk' )
+				__( 'Comments are managed by Coral Project. (%ssettings%s)', 'coral-project-talk' )
 			);
 		}
 	}

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -160,6 +160,7 @@ class Talk_Settings_Page {
 	 * @since 0.0.3
 	 */
 	public function render_version_field() {
+		$talk_version = esc_attr( get_option( 'coral_talk_version' ) )
 		?>
 		<select
 			style="width: 600px; height: 40px;"
@@ -170,7 +171,7 @@ class Talk_Settings_Page {
 		>
 			<option value="4"
 				<?php 
-					if (esc_attr( get_option( 'coral_talk_version' ) ) === "4")
+					if ($talk_version === "4")
 						echo "selected=\"selected\""
 				?>
 			>
@@ -178,7 +179,7 @@ class Talk_Settings_Page {
 			</option>
 			<option value="5"
 				<?php 
-					if (esc_attr( get_option( 'coral_talk_version' ) ) === "5")
+					if ($talk_version === "5")
 						echo "selected=\"selected\""
 				?>
 			>

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -76,6 +76,15 @@ class Talk_Settings_Page {
 			'about-talk'
 		);
 		register_setting( 'talk-settings', 'coral_talk_container_classes' );
+
+		add_settings_field(
+			'coral_talk_version',
+			__( 'Talk version', 'coral-project-talk' ),
+			array( $this, 'render_version_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_talk_version' );
 	}
 
 	/**
@@ -142,6 +151,40 @@ class Talk_Settings_Page {
 			type="text"
 			value="<?php echo esc_attr( get_option( 'coral_talk_container_classes' ) ); ?>"
 		/>
+		<?php
+	}
+
+	/**
+	 * Prints drop down for version.
+	 *
+	 * @since 0.0.3
+	 */
+	public function render_version_field() {
+		?>
+		<select
+			style="width: 600px; height: 40px;"
+			name="coral_talk_version"
+			placeholder=""
+			id="coral_talk_version"
+			type="select"
+		>
+			<option value="4"
+				<?php 
+					if (esc_attr( get_option( 'coral_talk_version' ) ) === "4")
+						echo "selected=\"selected\""
+				?>
+			>
+				4
+			</option>
+			<option value="5"
+				<?php 
+					if (esc_attr( get_option( 'coral_talk_version' ) ) === "5")
+						echo "selected=\"selected\""
+				?>
+			>
+				5
+			</option>
+		</select>
 		<?php
 	}
 

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -20,8 +20,8 @@ class Talk_Settings_Page {
 	 */
 	public function register_settings_page() {
 		add_options_page(
-			__( 'Talk Settings', 'coral-project-talk' ),
-			__( 'Talk Settings', 'coral-project-talk' ),
+			__( 'Coral Settings', 'coral-project-talk' ),
+			__( 'Coral Settings', 'coral-project-talk' ),
 			'manage_options',
 			'talk-settings',
 			array( $this, 'render_settings_page' )
@@ -37,7 +37,7 @@ class Talk_Settings_Page {
 	public function setup_settings_page() {
 		add_settings_section(
 			'about-talk',
-			__( 'About Talk', 'coral-project-talk' ),
+			__( 'About Coral', 'coral-project-talk' ),
 			function() {
 				require_once( CORAL_PROJECT_TALK_DIR . '/inc/talk-settings-static-content.php' );
 			},
@@ -46,7 +46,7 @@ class Talk_Settings_Page {
 
 		add_settings_field(
 			'coral_talk_base_url',
-			__( 'Talk Server Base URL', 'coral-project-talk' ),
+			__( 'Server Base URL', 'coral-project-talk' ),
 			array( $this, 'render_base_url_field' ),
 			'talk-settings',
 			'about-talk'
@@ -58,7 +58,7 @@ class Talk_Settings_Page {
 
 		add_settings_field(
 			'coral_talk_static_url',
-			__( 'Talk Static Asset URL', 'coral-project-talk' ),
+			__( 'Static Asset URL', 'coral-project-talk' ),
 			array( $this, 'render_static_url_field' ),
 			'talk-settings',
 			'about-talk'
@@ -70,7 +70,7 @@ class Talk_Settings_Page {
 
 		add_settings_field(
 			'coral_talk_container_classes',
-			__( 'Talk Embed Container CSS Classes', 'coral-project-talk' ),
+			__( 'Embed Container CSS Classes', 'coral-project-talk' ),
 			array( $this, 'render_container_classes_field' ),
 			'talk-settings',
 			'about-talk'
@@ -79,7 +79,7 @@ class Talk_Settings_Page {
 
 		add_settings_field(
 			'coral_talk_version',
-			__( 'Talk version', 'coral-project-talk' ),
+			__( 'Version', 'coral-project-talk' ),
 			array( $this, 'render_version_field' ),
 			'talk-settings',
 			'about-talk'
@@ -108,12 +108,12 @@ class Talk_Settings_Page {
 		<input
 			style="width: 600px; height: 40px;"
 			name="coral_talk_base_url"
-			placeholder="https://talk.my-site.com"
+			placeholder="https://coral.my-site.com"
 			id="coral_talk_base_url"
 			type="url"
 			value="<?php echo esc_url( get_option( 'coral_talk_base_url' ) ); ?>"
 		/>
-		<p class="description">The root url of the installed Talk application. This is the same value as <a href="<?php echo esc_url( 'https://docs.coralproject.net/talk/configuration/#talk-root-url' ); ?>">TALK_ROOT_URL</a> defined in the Talk application configuration.</p>
+		<p class="description">The root url of the installed Coral application. This is the same value as <a href="<?php echo esc_url( 'https://docs.coralproject.net/talk/configuration/#talk-root-url' ); ?>">ROOT_URL</a> defined in the Coral application configuration.</p>
 		<?php
 	}
 
@@ -132,7 +132,7 @@ class Talk_Settings_Page {
 				type="url"
 				value="<?php echo esc_url( get_option( 'coral_talk_static_url' ) ); ?>"
 		/>
-		<p class="description">The root url where static Talk assets should be served from. This is the same value as <a href="<?php echo esc_url( 'https://docs.coralproject.net/talk/advanced-configuration/#talk-static-uri' ); ?>">TALK_STATIC_URI</a> defined in the Talk application configuration.</p>
+		<p class="description">The root url where static Coral assets should be served from. This is the same value as <a href="<?php echo esc_url( 'https://docs.coralproject.net/talk/advanced-configuration/#talk-static-uri' ); ?>">STATIC_URI</a> defined in the Coral application configuration.</p>
 		<?php
 	}
 
@@ -196,7 +196,7 @@ class Talk_Settings_Page {
 	public function render_settings_page() {
 		?>
 		<div class="wrap">
-			<h2><?php esc_html_e( 'Talk Settings', 'coral-project-talk' ) ?></h2>
+			<h2><?php esc_html_e( 'Coral Settings', 'coral-project-talk' ) ?></h2>
 			<form method="post" action="options.php">
 				<?php
 				settings_fields( 'talk-settings' );

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -40,6 +40,7 @@ if ( $talk_version == "5" ) : ?>
 				id: "coral_thread",
 				autoRender: true,
 				rootURL: "<?php echo esc_url( $talk_url ); ?>",
+				storyID: "<?php echo get_the_ID(); ?>",
 			});
 		};
 		(d.head || d.body).appendChild(s);

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -11,12 +11,38 @@
 $talk_url = get_option( 'coral_talk_base_url' );
 $static_url = get_option( 'coral_talk_static_url', $talk_url );
 $talk_container_classes = get_option( 'coral_talk_container_classes' );
+$talk_version = get_option( 'coral_talk_version' );
+
 $div_id = 'coral_talk_' . absint( rand() );
-if ( ! empty( $talk_url ) ) : ?>
+
+if ( empty( $talk_url) ):
+	exit();
+endif;
+
+if ( $talk_version == "4" ) : ?>
 	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="<?php echo esc_attr( $div_id ); ?>"></div>
 	<script src="<?php echo esc_url( $static_url . '/static/embed.js' ); ?>" async onload="
 		Coral.talkStream = Coral.Talk.render(document.getElementById('<?php echo esc_js( $div_id ); ?>'), {
 			talk: '<?php echo esc_url( $talk_url ); ?>'
 		});
 	"></script>
+<?php endif;
+
+
+if ( $talk_version == "5" ) : ?>
+	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="coral_thread"></div>
+	<script type="text/javascript">
+	(function() {
+		var d = document, s = d.createElement('script');
+		s.src = "<?php echo esc_url( $talk_url . '/assets/js/embed.js' ); ?>"
+		s.onload = function() {
+			Coral.createStreamEmbed({
+				id: "coral_thread",
+				autoRender: true,
+				rootURL: "<?php echo esc_url( $talk_url ); ?>",
+			});
+		};
+		(d.head || d.body).appendChild(s);
+	})();
+	</script>
 <?php endif;

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -19,16 +19,6 @@ if ( empty( $talk_url) ):
 	exit();
 endif;
 
-if ( $talk_version == "4" ) : ?>
-	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="<?php echo esc_attr( $div_id ); ?>"></div>
-	<script src="<?php echo esc_url( $static_url . '/static/embed.js' ); ?>" async onload="
-		Coral.talkStream = Coral.Talk.render(document.getElementById('<?php echo esc_js( $div_id ); ?>'), {
-			talk: '<?php echo esc_url( $talk_url ); ?>'
-		});
-	"></script>
-<?php endif;
-
-
 if ( $talk_version == "5" ) : ?>
 	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="coral_thread"></div>
 	<script type="text/javascript">
@@ -46,4 +36,13 @@ if ( $talk_version == "5" ) : ?>
 		(d.head || d.body).appendChild(s);
 	})();
 	</script>
+<?php endif;
+
+if ( $talk_version != "5" ) : ?>
+	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="<?php echo esc_attr( $div_id ); ?>"></div>
+	<script src="<?php echo esc_url( $static_url . '/static/embed.js' ); ?>" async onload="
+		Coral.talkStream = Coral.Talk.render(document.getElementById('<?php echo esc_js( $div_id ); ?>'), {
+			talk: '<?php echo esc_url( $talk_url ); ?>'
+		});
+	"></script>
 <?php endif;

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -36,9 +36,8 @@ if ( $talk_version == "5" ) : ?>
 		(d.head || d.body).appendChild(s);
 	})();
 	</script>
-<?php endif;
-
-if ( $talk_version != "5" ) : ?>
+<?php
+else : ?>
 	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="<?php echo esc_attr( $div_id ); ?>"></div>
 	<script src="<?php echo esc_url( $static_url . '/static/embed.js' ); ?>" async onload="
 		Coral.talkStream = Coral.Talk.render(document.getElementById('<?php echo esc_js( $div_id ); ?>'), {

--- a/inc/talk-settings-static-content.php
+++ b/inc/talk-settings-static-content.php
@@ -8,20 +8,20 @@
 ?>
 <p>
 	<?php printf(
-		esc_html__( 'You can find out how to install and manage Talk %shere%s.', 'coral-project-talk' ),
+		esc_html__( 'You can find out how to install and manage Coral %shere%s.', 'coral-project-talk' ),
 		'<a href="https://docs.coralproject.net/talk/">',
 		'</a>'
 	); ?>
 </p>
 <p>
 	<?php printf(
-		esc_html__( 'Talk is an open source product brought to you by The Coral Project. Find out more about Coral and the tools we build %shere%s.', 'coral-project-talk' ),
+		esc_html__( 'Coral is an open source product brought to you by The Coral Project. Find out more about Coral and the tools we build %shere%s.', 'coral-project-talk' ),
 		'<a href="https://coralproject.net">',
 		'</a>'
 	); ?>
 </p>
 
-<h2><?php esc_html_e( 'Talk Settings', 'coral-project-talk' ); ?></h2>
+<h2><?php esc_html_e( 'Coral Settings', 'coral-project-talk' ); ?></h2>
 <p>
 	<?php printf(
 		esc_html__( 'Questions/feedback? Reach out to us on %sTwitter%s or join our %sCommunity%s.', 'coral-project-talk' ),
@@ -33,7 +33,7 @@
 </p>
 <p>
 	<?php printf(
-		esc_html__( 'You are using version %s of the Talk WordPress Plugin. View the code, documentation, and latest releases %shere%s.', 'coral-project-talk' ),
+		esc_html__( 'You are using version %s of the Coral WordPress Plugin. View the code, documentation, and latest releases %shere%s.', 'coral-project-talk' ),
 		esc_html( get_plugin_data( CORAL_PROJECT_TALK_DIR . '/talk.php' )['Version'] ),
 		'<a href="https://github.com/coralproject/talk-wp-plugin">',
 		'</a>'

--- a/talk.php
+++ b/talk.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: Coral Project Talk
+ * Plugin Name: Coral Project
  * Plugin URI: https://coralproject.net
- * Description: A plugin to replace stock WP commenting with Talk from the Coral Project
+ * Description: A plugin to replace stock WP commenting with Coral Project comments.
  * Version: 0.1.0
  * Author: Alley Interactive, The Coral Project
  * Author URI: https://www.alleyinteractive.com
@@ -33,7 +33,7 @@ class Talk_Plugin {
 			if ( ! coral_talk_plugin_is_usable() ) {
 				coral_talk_print_admin_notice(
 					'warning',
-					__( 'The Base URL is required in %sCoral Talk settings%s', 'coral-project-talk' )
+					__( 'The Base URL is required in %sCoral Plugin settings%s', 'coral-project-talk' )
 				);
 			}
 		} );

--- a/talk.php
+++ b/talk.php
@@ -3,7 +3,7 @@
  * Plugin Name: Coral Project
  * Plugin URI: https://coralproject.net
  * Description: A plugin to replace stock WP commenting with Coral Project comments.
- * Version: 0.1.0
+ * Version: 0.2.0
  * Author: Alley Interactive, The Coral Project
  * Author URI: https://www.alleyinteractive.com
  * License: Apache 2.0


### PR DESCRIPTION
This updates the plugin to allow switching between version 4 and 5.

Instructions for how to setup a local development environment to test this is available at:

https://app.tettra.co/teams/coralproject/pages/wordpress-development-environment