### PR TITLE
[CORL-3018]: Update settings, docs, AMP support and bump to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # Coral WP Plugin
 
-This plugin replaces standard WordPress commenting with [Coral by Vox Media](https://coralproject.net). The open-source commenting platform that rethinks
-how moderation, comment display, and conversation function, creating the
-opportunity for safer, smarter discussions.
+This plugin replaces standard WordPress commenting with [Coral by Vox Media](https://coralproject.net). Coral is an open-source commenting platform that rethinks how moderation, comment display, and conversation function, creating the opportunity for safer, smarter discussions.
 
 ## Setup
 
-First, you'll need a server running your own instance of Coral. See the [Coral Docs](https://docs.coralproject.net/talk/) for more info about that.
+First, you'll need a server running your own instance of Coral. See the [Coral Docs](https://docs.coralproject.net/) for more info about that.
 
 Then...
 
 1. Add the hostname of your WordPress site to the whitelist in the settings of your Coral instance.
 1. Install and activate this plugin as you would any other WordPress plugin.
 1. Go to `https://mysite.com/wp-admin/options-general.php?page=talk-settings`
-1. Enter the URL of your Coral instance and click Save.
+1. Add the URL of your Coral instance to `Server Base URL` in Settings and click Save.
+1. Review and complete any further Settings and click Save.
 
 ## HTTPS and Dev Mode
 
@@ -48,6 +47,7 @@ Coral v4.9.0+ comes with AMP support. This plugin automatically integrates with 
 If you are building a custom theme, you can use `coral_talk_comments_amp_template()` to add the Coral AMP Iframe.
 
 ## Version
+
 Coral version <= `v3.9.1` use plugin version `v0.0.6`
 
 Coral version >= `4.0.0` use plugin version `v0.1.0`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then you will need to:
 
 ## Story settings
 
-The plugin uses the canonical URL for a Wordpress post for the Coral Story URL.
+The plugin supports enabling canonical URLs for a Wordpress post to be passed through to the Coral stream embed as the story URL.
 
 The plugin also supports setting a story mode and sending it through to the Coral stream embed. To use, you can add a custom field in Wordpress called `coralStoryMode` and then set it to a valid story mode.
 
@@ -24,7 +24,7 @@ The plugin also supports setting a story mode and sending it through to the Cora
 
 Your site must be served over `https` in order to integrate with Coral **unless** Coral is set to dev mode.
 
-If you're installing Coral with Docker, you can do that by adding `NODE_ENV=dev` to the environment variables in your [`docker-compose.yml`](https://docs.coralproject.net/environment-variables#node_env). Otherwise, any method of setting `process.env.NODE_ENV = 'dev'` will do the trick.
+If you're installing Coral with Docker, you can do that by adding `NODE_ENV=development` to the environment variables in your [`docker-compose.yml`](https://docs.coralproject.net/environment-variables#node_env). Otherwise, any method of setting `NODE_ENV=development` will do the trick.
 
 ## Theme usage
 
@@ -58,4 +58,4 @@ Coral version <= `v3.9.1` use plugin version `v0.0.6`
 
 Coral version >= `4.0.0` use plugin version `v0.1.0`
 
-Coral version >= `5.0.0` use plugin version `v0.2.1`
+Coral version >= `5.0.0` use plugin version `v1.0.0`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The plugin uses the canonical URL for a Wordpress post for the Coral Story URL.
 
 Your site must be served over `https` in order to integrate with Coral **unless** Coral is set to dev mode.
 
-If you're installing Coral with Docker, you can do that by adding `NODE_ENV=dev` to the environment variables in your [`docker-compose.yml`](https://docs.coralproject.net/talk/installation-from-docker/). Otherwise, any method of setting `process.env.NODE_ENV = 'dev'` will do the trick.
+If you're installing Coral with Docker, you can do that by adding `NODE_ENV=dev` to the environment variables in your [`docker-compose.yml`](https://docs.coralproject.net/environment-variables#node_env). Otherwise, any method of setting `process.env.NODE_ENV = 'dev'` will do the trick.
 
 ## Theme usage
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ This plugin replaces standard WordPress commenting with [Coral by Vox Media](htt
 
 First, you'll need a server running your own instance of Coral. See the [Coral Docs](https://docs.coralproject.net/) for more info about that.
 
-Then...
+Then you will need to:
 
 1. Add the hostname of your WordPress site to the whitelist in the settings of your Coral instance.
 1. Install and activate this plugin as you would any other WordPress plugin.
 1. Go to `https://mysite.com/wp-admin/options-general.php?page=talk-settings`
 1. Add the URL of your Coral instance to `Server Base URL` in Settings and click Save.
 1. Review and complete any further Settings and click Save.
+
+## Story settings
+
+Coral will use the canonical URL for a Wordpress post for the Story URL.
 
 ## HTTPS and Dev Mode
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Then you will need to:
 
 The plugin uses the canonical URL for a Wordpress post for the Coral Story URL.
 
+The plugin also supports setting a story mode and sending it through to the Coral stream embed. To use, you can add a custom field in Wordpress called `coralStoryMode` and then set it to a valid story mode.
+
 ## HTTPS and Dev Mode
 
 Your site must be served over `https` in order to integrate with Coral **unless** Coral is set to dev mode.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then you will need to:
 
 ## Story settings
 
-Coral will use the canonical URL for a Wordpress post for the Story URL.
+The plugin uses the canonical URL for a Wordpress post for the Coral Story URL.
 
 ## HTTPS and Dev Mode
 

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -69,15 +69,6 @@ class Talk_Settings_Page {
 		) );
 
 		add_settings_field(
-			'coral_stream_id',
-			__( 'Stream ID', 'coral-project-talk' ),
-			array( $this, 'render_stream_id_field' ),
-			'talk-settings',
-			'about-talk'
-		);
-		register_setting( 'talk-settings', 'coral_stream_id');
-
-		add_settings_field(
 			'coral_talk_container_classes',
 			__( 'Embed Container CSS Classes', 'coral-project-talk' ),
 			array( $this, 'render_container_classes_field' ),
@@ -193,20 +184,6 @@ class Talk_Settings_Page {
 				value="<?php echo esc_url( get_option( 'coral_talk_static_url' ) ); ?>"
 		/>
 		<p class="description">The root url where static Coral assets should be served from. This is the same value as <a href="<?php echo esc_url( 'https://docs.coralproject.net/talk/advanced-configuration/#talk-static-uri' ); ?>">STATIC_URI</a> defined in the Coral application configuration.</p>
-		<?php
-	}
-
-	public function render_stream_id_field() {
-		?>
-		<input
-				style="width: 600px; height: 40px;"
-				name="coral_stream_id"
-				placeholder="coral-embed-stream"
-				id="coral_stream_id"
-				type="text"
-				value="<?php echo esc_attr( get_option( 'coral_stream_id' ) ); ?>"
-		/>
-		<p class="description">ID of a DOM element on the page into which the comment stream will be rendered.</p>
 		<?php
 	}
 

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -87,13 +87,28 @@ class Talk_Settings_Page {
 		register_setting( 'talk-settings', 'coral_talk_version' );
 
 		add_settings_field(
-			'coral_story_id',
-			__( 'Story ID', 'coral-project-talk' ),
-			array($this, 'render_story_id_field'),
+			'coral_custom_css_url',
+			__( 'Custom CSS URL', 'coral-project-talk' ),
+			array( $this, 'render_custom_css_url_field' ),
 			'talk-settings',
 			'about-talk'
 		);
-		register_setting( 'talk-settings', 'coral_story_id' );
+		register_setting( 'talk-settings', 'coral_custom_css_url', array(
+			'type' => 'string',
+			'sanitize_callback' => array( $this, 'sanitize_url' ),
+		) );
+
+		add_settings_field(
+			'coral_custom_fonts_css_url',
+			__( 'Custom Fonts CSS URL', 'coral-project-talk' ),
+			array( $this, 'render_custom_fonts_css_url_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_custom_fonts_css_url', array(
+			'type' => 'string',
+			'sanitize_callback' => array( $this, 'sanitize_url' ),
+		) );
 	}
 
 	/**
@@ -145,6 +160,34 @@ class Talk_Settings_Page {
 		<?php
 	}
 
+	public function render_custom_css_url_field() {
+		?>
+		<input
+				style="width: 600px; height: 40px;"
+				name="coral_custom_css_url"
+				placeholder="https://cdn.talk-assets.com/coral_custom.css"
+				id="coral_custom_css_url"
+				type="url"
+				value="<?php echo esc_url( get_option( 'coral_custom_css_url' ) ); ?>"
+		/>
+		<p class="description">URL for a custom stylesheet to be included to style this Coral stream. To configure a custom stylesheet for all streams, see advanced configuration options in the admin.</p>
+		<?php
+	}
+
+	public function render_custom_fonts_css_url_field() {
+		?>
+		<input
+				style="width: 600px; height: 40px;"
+				name="coral_custom_fonts_css_url"
+				placeholder="https://cdn.talk-assets.com/coral_custom_fonts.css"
+				id="coral_custom_fonts_css_url"
+				type="url"
+				value="<?php echo esc_url( get_option( 'coral_custom_fonts_css_url' ) ); ?>"
+		/>
+		<p class="description">URL for a custom stylesheet with font-face definitions to be included to style this Coral stream. To configure a custom stylesheet for all streams, see advanced configuration options in the admin.</p>
+		<?php
+	}
+
 	/**
 	 * Prints input field for settings.
 	 *
@@ -162,21 +205,6 @@ class Talk_Settings_Page {
 		/>
 		<?php
 	}
-
-	public function render_story_id_field() {
-		?>
-		<input
-			style="width: 600px; height: 40px;"
-			name="coral_story_id"
-			placeholder=""
-			id="coral_story_id"
-			type="text"
-			value="<?php echo esc_attr( get_option( 'coral_story_id' ) ); ?>"
-		/>
-		<p class="description">ID for the story. May alternately specify via Story URL or allow Coral to scrape and determine automatically. If used without a Story URL, the coment stream will use the canonical URL of the page it's running on as the Story URL.</p>
-		<?php
-	}
-
 	/**
 	 * Prints drop down for version.
 	 *

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -253,17 +253,17 @@ class Talk_Settings_Page {
 				type="select"
 				value="<?php echo esc_url( get_option( 'coral_disable_default_fonts' ) ); ?>"
 		>
-		<option value="true"
+		<option value="1"
 				<?php 
-					if ($coral_disable_default_fonts === "true")
+					if ($coral_disable_default_fonts === "1")
 						echo "selected=\"selected\""
 				?>
 			>
 				true
 			</option>
-			<option value="false"
+			<option value="0"
 				<?php 
-					if ($coral_disable_default_fonts === "false")
+					if ($coral_disable_default_fonts === "0")
 						echo "selected=\"selected\""
 				?>
 			>

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -169,7 +169,7 @@ class Talk_Settings_Page {
 		<input
 				style="width: 600px; height: 40px;"
 				name="coral_talk_static_url"
-				placeholder="https://cdn.talk-assets.com"
+				placeholder="https://cdn.coral-assets.com"
 				id="coral_talk_static_url"
 				type="url"
 				value="<?php echo esc_url( get_option( 'coral_talk_static_url' ) ); ?>"
@@ -188,7 +188,7 @@ class Talk_Settings_Page {
 		<input
 				style="width: 600px; height: 40px;"
 				name="coral_custom_css_url"
-				placeholder="https://cdn.talk-assets.com/coral_custom.css"
+				placeholder="https://cdn.coral-assets.com/coral_custom.css"
 				id="coral_custom_css_url"
 				type="url"
 				value="<?php echo esc_url( get_option( 'coral_custom_css_url' ) ); ?>"
@@ -207,7 +207,7 @@ class Talk_Settings_Page {
 		<input
 				style="width: 600px; height: 40px;"
 				name="coral_custom_fonts_css_url"
-				placeholder="https://cdn.talk-assets.com/coral_custom_fonts.css"
+				placeholder="https://cdn.coral-assets.com/coral_custom_fonts.css"
 				id="coral_custom_fonts_css_url"
 				type="url"
 				value="<?php echo esc_url( get_option( 'coral_custom_fonts_css_url' ) ); ?>"

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -85,6 +85,15 @@ class Talk_Settings_Page {
 			'about-talk'
 		);
 		register_setting( 'talk-settings', 'coral_talk_version' );
+
+		add_settings_field(
+			'coral_story_id',
+			__( 'Story ID', 'coral-project-talk' ),
+			array($this, 'render_story_id_field'),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_story_id' );
 	}
 
 	/**
@@ -151,6 +160,20 @@ class Talk_Settings_Page {
 			type="text"
 			value="<?php echo esc_attr( get_option( 'coral_talk_container_classes' ) ); ?>"
 		/>
+		<?php
+	}
+
+	public function render_story_id_field() {
+		?>
+		<input
+			style="width: 600px; height: 40px;"
+			name="coral_story_id"
+			placeholder=""
+			id="coral_story_id"
+			type="text"
+			value="<?php echo esc_attr( get_option( 'coral_story_id' ) ); ?>"
+		/>
+		<p class="description">ID for the story. May alternately specify via Story URL or allow Coral to scrape and determine automatically. If used without a Story URL, the coment stream will use the canonical URL of the page it's running on as the Story URL.</p>
 		<?php
 	}
 

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -69,15 +69,6 @@ class Talk_Settings_Page {
 		) );
 
 		add_settings_field(
-			'coral_talk_container_classes',
-			__( 'Embed Container CSS Classes', 'coral-project-talk' ),
-			array( $this, 'render_container_classes_field' ),
-			'talk-settings',
-			'about-talk'
-		);
-		register_setting( 'talk-settings', 'coral_talk_container_classes' );
-
-		add_settings_field(
 			'coral_container_class_name',
 			__( 'Embed Container CSS Class', 'coral-project-talk' ),
 			array( $this, 'render_container_class_name_field' ),
@@ -164,7 +155,7 @@ class Talk_Settings_Page {
 			type="url"
 			value="<?php echo esc_url( get_option( 'coral_talk_base_url' ) ); ?>"
 		/>
-		<p class="description">The root url of the installed Coral application. This is the same value as <a href="<?php echo esc_url( 'https://docs.coralproject.net/talk/configuration/#talk-root-url' ); ?>">ROOT_URL</a> defined in the Coral application configuration.</p>
+		<p class="description"><span style="font-weight: bold;">* Required.</span> The root url of the installed Coral application.</p>
 		<?php
 	}
 
@@ -183,7 +174,7 @@ class Talk_Settings_Page {
 				type="url"
 				value="<?php echo esc_url( get_option( 'coral_talk_static_url' ) ); ?>"
 		/>
-		<p class="description">The root url where static Coral assets should be served from. This is the same value as <a href="<?php echo esc_url( 'https://docs.coralproject.net/talk/advanced-configuration/#talk-static-uri' ); ?>">STATIC_URI</a> defined in the Coral application configuration.</p>
+		<p class="description">The root url where static Coral assets should be served from. This is the same value as defined by the <a href="<?php echo esc_url( 'https://docs.coralproject.net/environment-variables#static_uri' ); ?>">STATIC_URI</a> environment variable.</p>
 		<?php
 	}
 
@@ -274,23 +265,6 @@ class Talk_Settings_Page {
 		<?php
 	}
 
-	/**
-	 * Prints input field for settings.
-	 *
-	 * @since 0.0.3
-	 */
-	public function render_container_classes_field() {
-		?>
-		<input
-			style="width: 600px; height: 40px;"
-			name="coral_talk_container_classes"
-			placeholder=""
-			id="coral_talk_container_classes"
-			type="text"
-			value="<?php echo esc_attr( get_option( 'coral_talk_container_classes' ) ); ?>"
-		/>
-		<?php
-	}
 	/**
 	 * Prints drop down for version.
 	 *

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -245,12 +245,12 @@ class Talk_Settings_Page {
 		<input
 			style="width: 600px; height: 40px;"
 			name="coral_custom_scroll_container"
-			placeholder=""
+			placeholder="myElementId"
 			id="coral_custom_scroll_container"
 			type="text"
 			value="<?php echo esc_attr( get_option( 'coral_custom_scroll_container' ) ); ?>"
 		/>
-		<p class="description">Supports a custom scroll container element if Coral is rendered outside of the render window.</p>
+		<p class="description">Supports a custom scroll container element if Coral is rendered outside of the render window. Add the element id you wish to use, and Coral will find it if it's in the document and send it through.</p>
 		<?php
 	}
 

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -235,6 +235,7 @@ class Talk_Settings_Page {
 	}
 
 	public function render_disable_default_fonts_field() {
+		$default_fonts = esc_attr( get_option( 'coral_disable_default_fonts' ) )
 		?>
 		<select
 				style="width: 600px; height: 40px;"
@@ -242,19 +243,18 @@ class Talk_Settings_Page {
 				placeholder=""
 				id="coral_disable_default_fonts"
 				type="select"
-				value="<?php echo esc_url( get_option( 'coral_disable_default_fonts' ) ); ?>"
 		>
-		<option value="1"
+		<option value="true"
 				<?php 
-					if ($coral_disable_default_fonts === "1")
+					if ($default_fonts === "true")
 						echo "selected=\"selected\""
 				?>
 			>
 				true
 			</option>
-			<option value="0"
+			<option value="false"
 				<?php 
-					if ($coral_disable_default_fonts === "0")
+					if ($default_fonts === "false")
 						echo "selected=\"selected\""
 				?>
 			>

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -69,6 +69,15 @@ class Talk_Settings_Page {
 		) );
 
 		add_settings_field(
+			'coral_stream_id',
+			__( 'Stream ID', 'coral-project-talk' ),
+			array( $this, 'render_stream_id_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_stream_id');
+
+		add_settings_field(
 			'coral_talk_container_classes',
 			__( 'Embed Container CSS Classes', 'coral-project-talk' ),
 			array( $this, 'render_container_classes_field' ),
@@ -76,6 +85,15 @@ class Talk_Settings_Page {
 			'about-talk'
 		);
 		register_setting( 'talk-settings', 'coral_talk_container_classes' );
+
+		add_settings_field(
+			'coral_container_class_name',
+			__( 'Embed Container CSS Class', 'coral-project-talk' ),
+			array( $this, 'render_container_class_name_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_container_class_name' );
 
 		add_settings_field(
 			'coral_talk_version',
@@ -109,6 +127,24 @@ class Talk_Settings_Page {
 			'type' => 'string',
 			'sanitize_callback' => array( $this, 'sanitize_url' ),
 		) );
+
+		add_settings_field(
+			'coral_disable_default_fonts',
+			__( 'Disable default fonts', 'coral-project-talk' ),
+			array( $this, 'render_disable_default_fonts_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_disable_default_fonts');
+
+		add_settings_field(
+			'coral_custom_scroll_container',
+			__( 'Custom scroll container', 'coral-project-talk' ),
+			array( $this, 'render_custom_scroll_container_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_custom_scroll_container' );
 	}
 
 	/**
@@ -160,6 +196,20 @@ class Talk_Settings_Page {
 		<?php
 	}
 
+	public function render_stream_id_field() {
+		?>
+		<input
+				style="width: 600px; height: 40px;"
+				name="coral_stream_id"
+				placeholder="coral-embed-stream"
+				id="coral_stream_id"
+				type="text"
+				value="<?php echo esc_attr( get_option( 'coral_stream_id' ) ); ?>"
+		/>
+		<p class="description">ID of a DOM element on the page into which the comment stream will be rendered.</p>
+		<?php
+	}
+
 	public function render_custom_css_url_field() {
 		?>
 		<input
@@ -185,6 +235,65 @@ class Talk_Settings_Page {
 				value="<?php echo esc_url( get_option( 'coral_custom_fonts_css_url' ) ); ?>"
 		/>
 		<p class="description">URL for a custom stylesheet with font-face definitions to be included to style this Coral stream. To configure a custom stylesheet for all streams, see advanced configuration options in the admin.</p>
+		<?php
+	}
+
+	public function render_container_class_name_field() {
+		?>
+		<input
+			style="width: 600px; height: 40px;"
+			name="coral_container_class_name"
+			placeholder=""
+			id="coral_container_class_name"
+			type="text"
+			value="<?php echo esc_attr( get_option( 'coral_container_class_name' ) ); ?>"
+		/>
+		<p class="description">HTML class name to add to the container of the stream embed for CSS targeting.</p>
+		<?php
+	}
+
+	public function render_custom_scroll_container_field() {
+		?>
+		<input
+			style="width: 600px; height: 40px;"
+			name="coral_custom_scroll_container"
+			placeholder=""
+			id="coral_custom_scroll_container"
+			type="text"
+			value="<?php echo esc_attr( get_option( 'coral_custom_scroll_container' ) ); ?>"
+		/>
+		<p class="description">Supports a custom scroll container element if Coral is rendered outside of the render window.</p>
+		<?php
+	}
+
+	public function render_disable_default_fonts_field() {
+		?>
+		<select
+				style="width: 600px; height: 40px;"
+				name="coral_disable_default_fonts"
+				placeholder=""
+				id="coral_disable_default_fonts"
+				type="select"
+				value="<?php echo esc_url( get_option( 'coral_disable_default_fonts' ) ); ?>"
+		>
+		<option value="true"
+				<?php 
+					if ($coral_disable_default_fonts === "true")
+						echo "selected=\"selected\""
+				?>
+			>
+				true
+			</option>
+			<option value="false"
+				<?php 
+					if ($coral_disable_default_fonts === "false")
+						echo "selected=\"selected\""
+				?>
+			>
+				false
+			</option>
+	</select>
+		<p class="description">Disable default fonts will turn off font-face loading of Coral's default fonts.</p>
 		<?php
 	}
 

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -141,7 +141,7 @@ class Talk_Settings_Page {
 	}
 
 	/**
-	 * Prints input field for settings.
+	 * Prints input field for base URL setting.
 	 *
 	 * @since 0.0.1
 	 */
@@ -178,6 +178,11 @@ class Talk_Settings_Page {
 		<?php
 	}
 
+	/**
+	 * Prints input field for custom CSS url setting.
+	 *
+	 * @since 1.0.0
+	 */
 	public function render_custom_css_url_field() {
 		?>
 		<input
@@ -192,6 +197,11 @@ class Talk_Settings_Page {
 		<?php
 	}
 
+	/**
+	 * Prints input field for custom fonts CSS url setting.
+	 *
+	 * @since 1.0.0
+	 */
 	public function render_custom_fonts_css_url_field() {
 		?>
 		<input
@@ -206,6 +216,11 @@ class Talk_Settings_Page {
 		<?php
 	}
 
+	/**
+	 * Prints input field for Coral container class name setting.
+	 *
+	 * @since 1.0.0
+	 */
 	public function render_container_class_name_field() {
 		?>
 		<input
@@ -220,6 +235,11 @@ class Talk_Settings_Page {
 		<?php
 	}
 
+	/**
+	 * Prints input field for custom scroll container setting.
+	 *
+	 * @since 1.0.0
+	 */
 	public function render_custom_scroll_container_field() {
 		?>
 		<input
@@ -234,6 +254,11 @@ class Talk_Settings_Page {
 		<?php
 	}
 
+	/**
+	 * Prints input field for disable default fonts setting.
+	 *
+	 * @since 1.0.0
+	 */
 	public function render_disable_default_fonts_field() {
 		$default_fonts = esc_attr( get_option( 'coral_disable_default_fonts' ) )
 		?>

--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -127,6 +127,15 @@ class Talk_Settings_Page {
 			'about-talk'
 		);
 		register_setting( 'talk-settings', 'coral_custom_scroll_container' );
+
+		add_settings_field(
+			'coral_enable_canonical_story_urls',
+			__( 'Enable canonical story urls', 'coral-project-talk' ),
+			array( $this, 'render_enable_canonical_story_urls_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_enable_canonical_story_urls' );
 	}
 
 	/**
@@ -269,6 +278,42 @@ class Talk_Settings_Page {
 				id="coral_disable_default_fonts"
 				type="select"
 		>
+		<option value="false"
+				<?php 
+					if ($default_fonts === "false")
+						echo "selected=\"selected\""
+				?>
+			>
+				false
+			</option>
+		<option value="true"
+				<?php 
+					if ($default_fonts === "true")
+						echo "selected=\"selected\""
+				?>
+			>
+				true
+			</option>
+	</select>
+		<p class="description">Disable default fonts will turn off font-face loading of Coral's default fonts.</p>
+		<?php
+	}
+
+	/**
+	 * Prints input field for disable default fonts setting.
+	 *
+	 * @since 1.0.0
+	 */
+	public function render_enable_canonical_story_urls_field() {
+		$default_fonts = esc_attr( get_option( 'coral_enable_canonical_story_urls' ) )
+		?>
+		<select
+				style="width: 600px; height: 40px;"
+				name="coral_enable_canonical_story_urls"
+				placeholder=""
+				id="coral_enable_canonical_story_urls"
+				type="select"
+		>
 		<option value="true"
 				<?php 
 					if ($default_fonts === "true")
@@ -286,7 +331,7 @@ class Talk_Settings_Page {
 				false
 			</option>
 	</select>
-		<p class="description">Disable default fonts will turn off font-face loading of Coral's default fonts.</p>
+		<p class="description">When enabled, the canonical story URL will be passed through to the Coral stream embed.</p>
 		<?php
 	}
 

--- a/inc/comments-amp-template.php
+++ b/inc/comments-amp-template.php
@@ -16,7 +16,7 @@ if ( ! empty( $talk_url ) ) : ?>
         layout="responsive"
         sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-forms"
         resizable
-        src="<?php echo esc_url( $talk_url ); ?>/embed/stream/amp?storyURL=<?php echo urlencode(wp_get_canonical_url()); ?>&rootURL=<?php echo urlencode( $talk_url ); ?>">
+        src="<?php echo esc_url( $talk_url ); ?>/embed/stream/amp?storyURL=<?php echo urlencode(wp_get_canonical_url()); ?>">
         <div placeholder></div>
         <div overflow tabindex=0 role=button aria-label="Read more" style="position: relative; padding: 0.5rem; background: #CBD1D2; bottom: 0.5rem;">Read more</div>
     </amp-iframe>

--- a/inc/comments-amp-template.php
+++ b/inc/comments-amp-template.php
@@ -4,6 +4,8 @@
  *
  * @package Talk_Plugin
  * @since 0.2.0
+ * @since 1.0.0 Added support for sending through root url in iframe source. 
+ * Updated Read more button styles so it can be seen.
  */
 
 $talk_url = get_option( 'coral_talk_base_url' );
@@ -14,8 +16,8 @@ if ( ! empty( $talk_url ) ) : ?>
         layout="responsive"
         sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-forms"
         resizable
-        src="<?php echo esc_url( $talk_url ); ?>/embed/amp#asset_url=<?php echo urlencode(wp_get_canonical_url()); ?>">
+        src="<?php echo esc_url( $talk_url ); ?>/embed/stream/amp?storyURL=<?php echo urlencode(wp_get_canonical_url()); ?>&rootURL=<?php echo urlencode( $talk_url ); ?>">
         <div placeholder></div>
-        <div overflow tabindex=0 role=button aria-label="Read more">Read more</div>
+        <div overflow tabindex=0 role=button aria-label="Read more" style="position: relative; padding: 0.5rem; background: #CBD1D2; bottom: 0.5rem;">Read more</div>
     </amp-iframe>
 <?php endif;

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -12,6 +12,7 @@ $talk_url = get_option( 'coral_talk_base_url' );
 $static_url = get_option( 'coral_talk_static_url', $talk_url );
 $talk_container_classes = get_option( 'coral_talk_container_classes' );
 $talk_version = get_option( 'coral_talk_version' );
+$coral_story_id = get_option('coral_story_id', null);
 
 $div_id = 'coral_talk_' . absint( rand() );
 
@@ -29,7 +30,8 @@ if ( $talk_version == "5" ) : ?>
 			Coral.createStreamEmbed({
 				id: "coral_thread",
 				autoRender: true,
-				rootURL: "<?php echo esc_url( $talk_url ); ?>"
+				rootURL: "<?php echo esc_url( $talk_url ); ?>",
+				storyID: "<?php echo esc_attr( $coral_story_id ); ?>",
 			});
 		};
 		(d.head || d.body).appendChild(s);

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -14,7 +14,6 @@ $talk_container_classes = get_option( 'coral_talk_container_classes' );
 $talk_version = get_option( 'coral_talk_version' );
 $coral_custom_css_url = get_option( 'coral_custom_css_url', null );
 $coral_custom_fonts_css_url = get_option( 'coral_custom_fonts_css_url', null );
-$coral_stream_id = get_option( 'coral_stream_id', "coral_thread");
 $coral_container_class_name = get_option( 'coral_container_class_name', null);
 $coral_disable_default_fonts = get_option( 'coral_disable_default_fonts' );
 $coral_custom_scroll_container = get_option( 'coral_custom_scroll_container', null );
@@ -33,7 +32,7 @@ if ( $talk_version == "5" ) : ?>
 		s.src = "<?php echo esc_url( $talk_url . '/assets/js/embed.js' ); ?>"
 		s.onload = function() {
 			Coral.createStreamEmbed({
-				id: "<?php echo esc_attr( $coral_stream_id ); ?>",
+				id: "coral_thread",
 				autoRender: true,
 				rootURL: "<?php echo esc_url( $talk_url ); ?>",
 				containerClassName: "<?php echo esc_attr( $coral_container_class_name ); ?>",

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -10,7 +10,6 @@
 
 $talk_url = get_option( 'coral_talk_base_url' );
 $static_url = get_option( 'coral_talk_static_url', $talk_url );
-$talk_container_classes = get_option( 'coral_talk_container_classes' );
 $talk_version = get_option( 'coral_talk_version' );
 $coral_custom_css_url = get_option( 'coral_custom_css_url', null );
 $coral_custom_fonts_css_url = get_option( 'coral_custom_fonts_css_url', null );
@@ -25,7 +24,7 @@ if ( empty( $talk_url ) || is_attachment() ):
 endif;
 
 if ( $talk_version == "5" ) : ?>
-	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="coral_thread"></div>
+	<div id="coral_thread"></div>
 	<script type="text/javascript">
 	(function() {
 		var d = document, s = d.createElement('script');

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -36,6 +36,7 @@ if ( $talk_version == "5" ) : ?>
 		const disableDefaultFonts = "<?php echo esc_attr( $coral_disable_default_fonts ); ?>" === "true";
 		s.src = "<?php echo esc_url( $talk_url . '/assets/js/embed.js' ); ?>"
 		s.onload = function() {
+			const customScrollContainer = document.getElementById("<?php echo esc_attr( $coral_custom_scroll_container ); ?>") || undefined;
 			Coral.createStreamEmbed({
 				id: "coral_thread",
 				autoRender: true,
@@ -44,7 +45,7 @@ if ( $talk_version == "5" ) : ?>
 				customCSSURL: "<?php echo esc_url( $coral_custom_css_url ); ?>",
 				customFontsCSSURL: "<?php echo esc_url( $coral_custom_fonts_css_url ); ?>",
 				disableDefaultFonts: disableDefaultFonts,
-				customScrollContainer: "<?php echo esc_attr( $coral_custom_scroll_container ); ?>",
+				customScrollContainer: customScrollContainer,
 				storyURL: "<?php echo esc_url( $canonical_url ); ?>",
 				storyMode: "<?php echo esc_attr( $storyMode ); ?>",
 			});

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -16,6 +16,8 @@ $coral_custom_fonts_css_url = get_option( 'coral_custom_fonts_css_url', null );
 $coral_container_class_name = get_option( 'coral_container_class_name', null);
 $coral_disable_default_fonts = get_option( 'coral_disable_default_fonts' );
 $coral_custom_scroll_container = get_option( 'coral_custom_scroll_container', null );
+$canonical_url = wp_get_canonical_url();
+$storyMode = $post->coralStoryMode;
 
 $div_id = 'coral_talk_' . absint( rand() );
 
@@ -28,6 +30,7 @@ if ( $talk_version == "5" ) : ?>
 	<script type="text/javascript">
 	(function() {
 		var d = document, s = d.createElement('script');
+		const disableDefaultFonts = "<?php echo esc_attr( $coral_disable_default_fonts ); ?>" === "true";
 		s.src = "<?php echo esc_url( $talk_url . '/assets/js/embed.js' ); ?>"
 		s.onload = function() {
 			Coral.createStreamEmbed({
@@ -37,8 +40,10 @@ if ( $talk_version == "5" ) : ?>
 				containerClassName: "<?php echo esc_attr( $coral_container_class_name ); ?>",
 				customCSSURL: "<?php echo esc_url( $coral_custom_css_url ); ?>",
 				customFontsCSSURL: "<?php echo esc_url( $coral_custom_fonts_css_url ); ?>",
-				disableDefaultFonts: "<?php echo boolVal( $coral_disable_default_fonts ); ?>",
+				disableDefaultFonts: disableDefaultFonts,
 				customScrollContainer: "<?php echo esc_attr( $coral_custom_scroll_container ); ?>",
+				storyURL: "<?php echo esc_url( $canonical_url ); ?>",
+				storyMode: "<?php echo esc_attr( $storyMode ); ?>",
 			});
 		};
 		(d.head || d.body).appendChild(s);

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -38,8 +38,7 @@ if ( $talk_version == "5" ) : ?>
 				containerClassName: "<?php echo esc_attr( $coral_container_class_name ); ?>",
 				customCSSURL: "<?php echo esc_url( $coral_custom_css_url ); ?>",
 				customFontsCSSURL: "<?php echo esc_url( $coral_custom_fonts_css_url ); ?>",
-				// TODO: Make sure this is boolean not string
-				disableDefaultFonts: "<?php echo $coral_disable_default_fonts; ?>",
+				disableDefaultFonts: "<?php echo boolVal( $coral_disable_default_fonts ); ?>",
 				customScrollContainer: "<?php echo esc_attr( $coral_custom_scroll_container ); ?>",
 			});
 		};

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -19,6 +19,7 @@ $coral_custom_fonts_css_url = get_option( 'coral_custom_fonts_css_url', null );
 $coral_container_class_name = get_option( 'coral_container_class_name', null);
 $coral_disable_default_fonts = get_option( 'coral_disable_default_fonts' );
 $coral_custom_scroll_container = get_option( 'coral_custom_scroll_container', null );
+$enable_canonical_url = get_option( 'coral_enable_canonical_story_urls' );
 $canonical_url = wp_get_canonical_url();
 $storyMode = $post->coralStoryMode;
 
@@ -34,6 +35,7 @@ if ( $talk_version == "5" ) : ?>
 	(function() {
 		var d = document, s = d.createElement('script');
 		const disableDefaultFonts = "<?php echo esc_attr( $coral_disable_default_fonts ); ?>" === "true";
+		const storyURL = "<?php echo esc_attr( $enable_canonical_url ); ?>" === "true" ? "<?php echo esc_url( $canonical_url ); ?>" : undefined;
 		s.src = "<?php echo esc_url( $talk_url . '/assets/js/embed.js' ); ?>"
 		s.onload = function() {
 			const customScrollContainer = document.getElementById("<?php echo esc_attr( $coral_custom_scroll_container ); ?>") || undefined;
@@ -46,7 +48,7 @@ if ( $talk_version == "5" ) : ?>
 				customFontsCSSURL: "<?php echo esc_url( $coral_custom_fonts_css_url ); ?>",
 				disableDefaultFonts: disableDefaultFonts,
 				customScrollContainer: customScrollContainer,
-				storyURL: "<?php echo esc_url( $canonical_url ); ?>",
+				storyURL: storyURL,
 				storyMode: "<?php echo esc_attr( $storyMode ); ?>",
 			});
 		};

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -6,6 +6,9 @@
  *
  * @package Talk_Plugin
  * @since 0.0.3 Added support for talk container class and removed id
+ * @since 1.0.0 Added support for custom CSS url, custom fonts CSS url, 
+ * disable default fonts, custom scroll container, canonical story url, and story mode. Also
+ * updated support for container class name.
  */
 
 $talk_url = get_option( 'coral_talk_base_url' );

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -12,8 +12,12 @@ $talk_url = get_option( 'coral_talk_base_url' );
 $static_url = get_option( 'coral_talk_static_url', $talk_url );
 $talk_container_classes = get_option( 'coral_talk_container_classes' );
 $talk_version = get_option( 'coral_talk_version' );
-$coral_custom_css_url = get_option( 'coral_custom_css_url' );
-$coral_custom_fonts_css_url = get_option( 'coral_custom_fonts_css_url' );
+$coral_custom_css_url = get_option( 'coral_custom_css_url', null );
+$coral_custom_fonts_css_url = get_option( 'coral_custom_fonts_css_url', null );
+$coral_stream_id = get_option( 'coral_stream_id', "coral_thread");
+$coral_container_class_name = get_option( 'coral_container_class_name', null);
+$coral_disable_default_fonts = get_option( 'coral_disable_default_fonts' );
+$coral_custom_scroll_container = get_option( 'coral_custom_scroll_container', null );
 
 $div_id = 'coral_talk_' . absint( rand() );
 
@@ -29,11 +33,15 @@ if ( $talk_version == "5" ) : ?>
 		s.src = "<?php echo esc_url( $talk_url . '/assets/js/embed.js' ); ?>"
 		s.onload = function() {
 			Coral.createStreamEmbed({
-				id: "coral_thread",
+				id: "<?php echo esc_attr( $coral_stream_id ); ?>",
 				autoRender: true,
 				rootURL: "<?php echo esc_url( $talk_url ); ?>",
+				containerClassName: "<?php echo esc_attr( $coral_container_class_name ); ?>",
 				customCSSURL: "<?php echo esc_url( $coral_custom_css_url ); ?>",
-				customFontsCSSURL: "<?php echo esc_url( $coral_custom_fonts_css_url ); ?>"
+				customFontsCSSURL: "<?php echo esc_url( $coral_custom_fonts_css_url ); ?>",
+				// TODO: Make sure this is boolean not string
+				disableDefaultFonts: "<?php echo $coral_disable_default_fonts; ?>",
+				customScrollContainer: "<?php echo esc_attr( $coral_custom_scroll_container ); ?>",
 			});
 		};
 		(d.head || d.body).appendChild(s);

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -12,7 +12,8 @@ $talk_url = get_option( 'coral_talk_base_url' );
 $static_url = get_option( 'coral_talk_static_url', $talk_url );
 $talk_container_classes = get_option( 'coral_talk_container_classes' );
 $talk_version = get_option( 'coral_talk_version' );
-$coral_story_id = get_option('coral_story_id', null);
+$coral_custom_css_url = get_option( 'coral_custom_css_url' );
+$coral_custom_fonts_css_url = get_option( 'coral_custom_fonts_css_url' );
 
 $div_id = 'coral_talk_' . absint( rand() );
 
@@ -31,7 +32,8 @@ if ( $talk_version == "5" ) : ?>
 				id: "coral_thread",
 				autoRender: true,
 				rootURL: "<?php echo esc_url( $talk_url ); ?>",
-				storyID: "<?php echo esc_attr( $coral_story_id ); ?>",
+				customCSSURL: "<?php echo esc_url( $coral_custom_css_url ); ?>",
+				customFontsCSSURL: "<?php echo esc_url( $coral_custom_fonts_css_url ); ?>"
 			});
 		};
 		(d.head || d.body).appendChild(s);

--- a/inc/talk-settings-static-content.php
+++ b/inc/talk-settings-static-content.php
@@ -8,15 +8,15 @@
 ?>
 <p>
 	<?php printf(
-		esc_html__( 'You can find out how to install and manage Coral %shere%s.', 'coral-project-talk' ),
-		'<a href="https://docs.coralproject.net/">',
+		esc_html__( 'Coral is an open-source commenting platform brought to you by Vox Media. Find out more about Coral and the tools we build %shere%s.', 'coral-project-talk' ),
+		'<a href="https://coralproject.net" target="_blank">',
 		'</a>'
 	); ?>
 </p>
 <p>
 	<?php printf(
-		esc_html__( 'Coral is an open-source commenting platform brought to you by Vox Media. Find out more about Coral and the tools we build %shere%s.', 'coral-project-talk' ),
-		'<a href="https://coralproject.net">',
+		esc_html__( 'You can find out how to install and manage Coral %shere%s.', 'coral-project-talk' ),
+		'<a href="https://docs.coralproject.net/" target="_blank">',
 		'</a>'
 	); ?>
 </p>
@@ -24,18 +24,9 @@
 <h2><?php esc_html_e( 'Coral Settings', 'coral-project-talk' ); ?></h2>
 <p>
 	<?php printf(
-		esc_html__( 'Questions/feedback? Reach out to us on %sTwitter%s or join our %sCommunity%s.', 'coral-project-talk' ),
-		'<a href="https://twitter.com/coralproject">',
-		'</a>',
-		'<a href="https://community.coralproject.net/">',
-		'</a>'
-	); ?>
-</p>
-<p>
-	<?php printf(
 		esc_html__( 'You are using version %s of the Coral WordPress Plugin. View the code, documentation, and latest releases %shere%s.', 'coral-project-talk' ),
 		esc_html( get_plugin_data( CORAL_PROJECT_TALK_DIR . '/talk.php' )['Version'] ),
-		'<a href="https://github.com/coralproject/talk-wp-plugin">',
+		'<a href="https://github.com/coralproject/talk-wp-plugin" target="_blank">',
 		'</a>'
 	); ?>
 </p>

--- a/inc/talk-settings-static-content.php
+++ b/inc/talk-settings-static-content.php
@@ -9,13 +9,13 @@
 <p>
 	<?php printf(
 		esc_html__( 'You can find out how to install and manage Coral %shere%s.', 'coral-project-talk' ),
-		'<a href="https://docs.coralproject.net/talk/">',
+		'<a href="https://docs.coralproject.net/">',
 		'</a>'
 	); ?>
 </p>
 <p>
 	<?php printf(
-		esc_html__( 'Coral is an open source product brought to you by The Coral Project. Find out more about Coral and the tools we build %shere%s.', 'coral-project-talk' ),
+		esc_html__( 'Coral is an open-source commenting platform brought to you by Vox Media. Find out more about Coral and the tools we build %shere%s.', 'coral-project-talk' ),
 		'<a href="https://coralproject.net">',
 		'</a>'
 	); ?>

--- a/talk.php
+++ b/talk.php
@@ -3,7 +3,7 @@
  * Plugin Name: Coral by Vox Media
  * Plugin URI: https://coralproject.net
  * Description: A plugin to replace stock WP commenting with Coral by Vox Media comments.
- * Version: 0.2.3
+ * Version: 1.0.0
  * Author: Coral by Vox Media, Alley Interactive
  * Author URI: https://www.coralproject.net
  * License: Apache 2.0


### PR DESCRIPTION
These changes move `talk-wp-plugin` to version 1.0.0.

The updates include:
- Settings:
  - container classes changes to singular `containerClassName` added to the Coral embed
  - add new field for custom CSS url
  - add new field for custom fonts CSS url
  - add new field for disabling default fonts
  - add new field for setting a custom scroll container by element id
  - use Wordpress canonical url for the story URL
  
- Docs:
  - Update incorrect links
  - Update outdated information and references
  
- AMP support
  - update iframe src url so that it will work as expected
  - update the `Read more` button with Coral comments AMP so that it is displayed and can be clicked on to show the rest of Coral comments
  